### PR TITLE
Add support for EL7, and other OS-specific changes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,4 +5,13 @@
   service:
     name: collector
     state: restarted
+  when: ansible_os_family != "RedHat" and ansible_distribution_major_version != "7"
+  tags: [sumologic, sumologic-collector]
+
+# Workaround a bug with SysV scripts on a SystemD-based OS, with ansible 1.x.
+# NOTE: A fix for this is in 2.x, so eventually it won't be needed
+#   https://github.com/ansible/ansible-modules-core/commit/55e8863cb448a19ff4ee7f1f65b78c3a44893cee
+- name: 'Restart SumoCollector - EL7'
+  command: service collector restart
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
   tags: [sumologic, sumologic-collector]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,13 +14,14 @@ galaxy_info:
   min_ansible_version: 1.7
   #
   # Below are all platforms currently available. Just uncomment
-  # the ones that apply to your role. If you don't see your 
+  # the ones that apply to your role. If you don't see your
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
   - name: EL
     versions:
     - 6
+    - 7
   #- name: EL
   #  versions:
   #  - all
@@ -132,4 +133,4 @@ dependencies: []
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,22 +3,25 @@
   command: dpkg-query -l sumocollector
   register: sumologic_collector_deb_check
   failed_when: no
+  when: ansible_os_family == "Debian"
   tags: sumologic
 
 - name: 'Download SumoColllector'
   get_url:
     url: '{{ sumocollector_installer_download }}'
     dest: '{{ sumologic_installer_remote_file }}'
-  when: sumologic_collector_deb_check.rc == 1
+  when: ansible_os_family == "Debian" and sumologic_collector_deb_check.rc == 1
   tags: sumologic
 
 - name: 'Install SumoCollector'
   apt:
     deb: '{{ sumologic_installer_remote_file }}'
     state: installed
-  when: sumologic_collector_deb_check.rc == 1
+  when: ansible_os_family == "Debian" and sumologic_collector_deb_check.rc == 1
   tags: sumologic
-  notify: Restart SumoCollector
+  notify:
+    - Restart SumoCollector
+    - Restart SumoCollector - EL7
 
 
 - name: 'Download SumoColllector redhat'
@@ -34,7 +37,9 @@
     state: present
   when: ansible_os_family == "RedHat"
   tags: sumologic
-  notify: Restart SumoCollector
+  notify:
+    - Restart SumoCollector
+    - Restart SumoCollector - EL7
 
 - name: 'Configure SumoCollector'
   template:
@@ -42,7 +47,9 @@
     dest: /etc/sumo.conf
   register: sumologic_collector_add_configuration
   tags: sumologic
-  notify: Restart SumoCollector
+  notify:
+    - Restart SumoCollector
+    - Restart SumoCollector - EL7
 
 - name: 'Define initial SumoCollector sources'
   set_fact:
@@ -54,4 +61,6 @@
     src: collector.json.j2
     dest: /etc/sumologic-collector.json
   tags: [sumologic, sumologic-collector]
-  notify: Restart SumoCollector
+  notify:
+    - Restart SumoCollector
+    - Restart SumoCollector - EL7


### PR DESCRIPTION
EL7 uses systemd, but the sumocollector installs a sysV init script
which causes errors when managing the service when using 1.x versions of
Ansible:

```
NOTIFIED: [sumocollector | Restart SumoCollector] *****************************
failed: [default] => {"failed": true}
msg: Failed to stop collector.service: Unit collector.service not loaded.
Failed to start collector.service: Unit collector.service failed to load: No such file or directory.
```

Also only run the deb tasks, when on a Debian ansible_os_family. Without
this, Ansible fails when run in check mode:

```
TASK: [sumocollector | Download SumoColllector] *******************************
fatal: [x.x.x.x] => error while evaluating conditional: sumologic_collector_deb_check.rc == 1
```
